### PR TITLE
onmount.teardown()

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,9 @@ Registers a behavior for `selector` to run the callback `init()`. The `exit()` c
 
 > The callbacks are passed an object `b`, and  the same object is passed for both `init` and `exit`. This allows them to communicate and keep aware of state. A string ID is also provided, `b.id`, which is guaranteed unique for every behavior-element pair.
 
+#### onmount.teardown()
+Forces the teardown of all currently-applied behaviors. This triggers the exit handlers for all behaviors currently on the page.
+
 #### onmount.reset()
 
 Clears all defined behaviors. Useful for tests.

--- a/docs/turbolinks.md
+++ b/docs/turbolinks.md
@@ -2,14 +2,21 @@
 
 onmount is a perfect fit with projects that use Turbolinks. You'll notice that jQuery's `document` `ready` event is not friendly for Turbolinks applications. You should call `$.onmount()` when Turbolinks changes pages.
 
-For Turbolinks 2 and below, the event is `page:change`:
+## Turbolinks v5
 
-```js
-$(document).on('ready page:change', function () { $.onmount() })
-```
-
-For Turbolinks 5, the event is `turbolinks:load`:
+The event is `turbolinks:load` for Turbolinks 5. You will also need to teardown behaviors on `turbolinks:before-cache` ([info](https://github.com/turbolinks/turbolinks/issues/30#issuecomment-195803051)).
 
 ```js
 $(document).on('ready turbolinks:load', function () { $.onmount() })
+$(document).on('turbolinks:before-cache', function () { $.onmount.teardown() })
+```
+
+Discussion on this setup may be found [here](https://github.com/rstacruz/onmount/issues/47#issuecomment-196751735).
+
+## Turbolinks v2
+
+The event is `page:change` For Turbolinks 2 and below.
+
+```js
+$(document).on('ready page:change', function () { $.onmount() })
 ```

--- a/index.js
+++ b/index.js
@@ -144,7 +144,7 @@ void (function (root, factory) {
   }
 
   /**
-   * Cleanup
+   * Forces teardown of all behaviors currently applied.
    */
 
   onmount.teardown = function teardown () {

--- a/index.js
+++ b/index.js
@@ -206,11 +206,12 @@ void (function (root, factory) {
 
     register(selector, function () {
       // This is the function invoked on `onmount(selector)`.
-      // It cleans up old ones and initialize new ones.
+      // Clean up old ones (if they're not in the DOM anymore).
       each(loaded, function (element, i) {
         be.visitExit(element, i)
       })
 
+      // Clean up new ones (if they're not loaded yet).
       query(selector, function () {
         be.visitEnter(this)
       })

--- a/index.js
+++ b/index.js
@@ -219,7 +219,7 @@ void (function (root, factory) {
   }
 
   /**
-   * Internal: visits the element `el` and turns it on if applicable
+   * Internal: visits the element `el` and turns it on if applicable.
    */
 
   Behavior.prototype.visitEnter = function (el) {
@@ -235,12 +235,17 @@ void (function (root, factory) {
 
   /**
    * Internal: visits the element `el` and sees if it needs its exit handler
-   * called
+   * called.
    */
 
   Behavior.prototype.visitExit = function (el, i) {
     if (el && !isAttached(el)) return this.doExit(el, i)
   }
+
+  /**
+   * Internal: calls the exit handler for the behavior for element `el` (if
+   * available), and marks the behavior/element as uninitialized.
+   */
 
   Behavior.prototype.doExit = function (el, i) {
     if (typeof i === 'undefined') i = this.loaded.indexOf(el)

--- a/index.js
+++ b/index.js
@@ -149,8 +149,8 @@ void (function (root, factory) {
 
   onmount.teardown = function teardown () {
     each(behaviors, function (be) {
-      each(be.loaded, function (el) {
-        be.doExit(el)
+      each(be.loaded, function (el, i) {
+        be.doExit(el, i)
       })
     })
   }

--- a/index.js
+++ b/index.js
@@ -97,8 +97,8 @@ void (function (root, factory) {
 
   onmount.poll = function poll (selector) {
     if (selector) selector = onmount.selectify(selector)
-    var list = (selector ? selectors[selector] : handlers) || []
-    each(list, function (item) { item() })
+    var functions = (selector ? selectors[selector] : handlers) || []
+    each(functions, function (fn) { fn() })
   }
 
   /**
@@ -144,6 +144,18 @@ void (function (root, factory) {
   }
 
   /**
+   * Cleanup
+   */
+
+  onmount.teardown = function teardown () {
+    each(behaviors, function (be) {
+      each(be.loaded, function (el) {
+        be.doExit(el)
+      })
+    })
+  }
+
+  /**
    * Clears all behaviors. Useful for tests.
    * This will NOT call exit handlers.
    */
@@ -183,7 +195,8 @@ void (function (root, factory) {
   }
 
   /**
-   * Internal: Register this behavior
+   * Internal: initialize this behavior by registering itself to the internal
+   * `selectors` map. This allows you to call `onmount(selector)` later on.
    */
 
   Behavior.prototype.register = function () {
@@ -192,7 +205,8 @@ void (function (root, factory) {
     var selector = this.selector
 
     register(selector, function () {
-      // clean up old ones and initialize new ones
+      // This is the function invoked on `onmount(selector)`.
+      // It cleans up old ones and initialize new ones.
       each(loaded, function (element, i) {
         be.visitExit(element, i)
       })
@@ -224,13 +238,15 @@ void (function (root, factory) {
    */
 
   Behavior.prototype.visitExit = function (el, i) {
-    if (el && !isAttached(el)) {
-      if (typeof i === 'undefined') i = this.loaded.indexOf(el)
-      this.loaded[i] = undefined
-      if (this.exit && this.exit.call(el, el[this.key]) !== false) {
-        if (onmount.debug) log('exit', this.selector, el)
-        delete el[this.key]
-      }
+    if (el && !isAttached(el)) return this.doExit(el, i)
+  }
+
+  Behavior.prototype.doExit = function (el, i) {
+    if (typeof i === 'undefined') i = this.loaded.indexOf(el)
+    this.loaded[i] = undefined
+    if (this.exit && this.exit.call(el, el[this.key]) !== false) {
+      if (onmount.debug) log('exit', this.selector, el)
+      delete el[this.key]
     }
   }
 

--- a/test/exiting_test.js
+++ b/test/exiting_test.js
@@ -28,6 +28,15 @@ exitingTest('calls the unloader', function (t) {
   t.end()
 })
 
+exitingTest('using onmount.teardown()', function (t) {
+  var div = el('div', { 'class': 'their-behavior' })
+  onmount()
+  onmount.teardown()
+
+  t.equal(div.innerHTML, '(on)(off)', 'ok')
+  t.end()
+})
+
 exitingTest('gets double-applied intentionally', function (t) {
   var div = el('div', { 'class': 'their-behavior' })
   onmount()

--- a/test/mounting_test.js
+++ b/test/mounting_test.js
@@ -22,6 +22,14 @@ mountingTest('onmount(selector)', function (t, div) {
   t.end()
 })
 
+mountingTest('onmount(selector) idempotency', function (t, div) {
+  onmount('.my-behavior')
+  onmount('.my-behavior')
+  onmount('.my-behavior')
+  t.equal(div.innerHTML, '(on)', "doesn't get called multiple times")
+  t.end()
+})
+
 mountingTest('onmount()', function (t, div) {
   onmount()
   t.equal(div.innerHTML, '(on)', 'works')
@@ -32,7 +40,7 @@ mountingTest('onmount() idempotency', function (t, div) {
   onmount()
   onmount()
   onmount()
-  t.equal(div.innerHTML, '(on)', 'works')
+  t.equal(div.innerHTML, '(on)', "doesn't get called multiple times")
   t.end()
 })
 


### PR DESCRIPTION
See #47. This implements `onmount.teardown()`. It forces the teardown of all currently-applied behaviors. This triggers the exit handlers for all behaviors currently on the page.

Useful for Turbolinks 5.