### PR TITLE
Fix onmount.teardown errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -150,7 +150,7 @@ void (function (root, factory) {
   onmount.teardown = function teardown () {
     each(behaviors, function (be) {
       each(be.loaded, function (el, i) {
-        be.doExit(el, i)
+        if (el) be.doExit(el, i)
       })
     })
   }


### PR DESCRIPTION
As mentioned here https://github.com/rstacruz/onmount/issues/47#issuecomment-197005105, `onmount.teardown` can run `exit` handlers too aggressively. This should fix that.