### PR TITLE
Issue 208: init function not ran on already existing nodes matching the selector

### DIFF
--- a/index.js
+++ b/index.js
@@ -64,6 +64,7 @@ void (function (root, factory) {
       var be = new Behavior(selector, init, exit, options)
       behaviors.push(be)
       be.register()
+      onmount.poll(selector)
     }
 
     return this


### PR DESCRIPTION
Re. https://github.com/rstacruz/onmount/issues/208

Polling for a behavior selector just after it has been registered.