### PR TITLE
Prevent error in one behavior stopping others

### DIFF
--- a/index.js
+++ b/index.js
@@ -97,7 +97,13 @@ void (function (root, factory) {
   onmount.poll = function poll (selector) {
     if (selector) selector = onmount.selectify(selector)
     var functions = (selector ? selectors[selector] : handlers) || []
-    each(functions, function (fn) { fn() })
+    each(functions, function (fn) {
+      try {
+        fn()
+      } catch (e) {
+        console.error(e)
+      }
+    })
   }
 
   /**


### PR DESCRIPTION
After calling `onmount()` to run all registered behaviors, we don't want an error in one of the behaviors causing any later behaviors fail.

Here's a minimal example:

```html
<div class="failing-thing"></div>
<div class="next-thing"></div>

<script type="text/javascript">
  onmount('.failing-thing', function(){
    throw new Error("I am an error");
  });
  onmount('.next-thing', function(){
    alert("I should be shown regardless of preceding errors, but I'm not.");
  });

  onmount(); //trigger all behaviors to run.
</script>

```

The alert message is never shown.

This PR simply runs each registered behavior in a `try/catch` block and logs the errors in the console, which I believe is more aligned with developer expectations.